### PR TITLE
Enable CI using Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: required
+
+language: generic
+
+services:
+  - docker
+
+script:
+  - "docker run --rm -ti -v $(pwd):/overlay -w /overlay gentoo/stage3-amd64 /overlay/tests/runtests.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,9 @@ language: generic
 services:
   - docker
 
+cache:
+  directories:
+  - $HOME/.portage
+
 script:
-  - "docker run --rm -ti -v $(pwd):/overlay -w /overlay gentoo/stage3-amd64 /overlay/tests/runtests.sh"
+  - "docker run --rm -ti -v $HOME/.portage:/usr/portage -v $PWD:/overlay -w /overlay gentoo/stage3-amd64 /overlay/tests/runtests.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+    - master
+
 sudo: required
 
 language: generic

--- a/README.md
+++ b/README.md
@@ -1,3 +1,33 @@
-# simonvanderveldt-overlay
+# simonvanderveldt-overlay [![Build Status](https://travis-ci.org/simonvanderveldt/simonvanderveldt-overlay.svg?branch=master)](https://travis-ci.org/simonvanderveldt/simonvanderveldt-overlay)
 
-Overlay with stuff that isn't available upstream or in other overlays.
+Overlay with applications that aren't available upstream or in other overlays, mainly music creation related.
+
+## How to use this overlay
+- Add an entry to [`/etc/portage/repos.conf`](https://wiki.gentoo.org/wiki//etc/portage/repos.conf):
+```ini
+[simonvanderveldt]
+# Use the location where you store your overlays
+location = /usr/local/overlay/simonvanderveldt
+sync-type = git
+sync-uri = https://github.com/simonvanderveldt/simonvanderveldt-overlay.git
+auto-sync = yes
+```
+- Sync
+```sh
+emerge --sync
+```
+- You're all set. Go and install a package :)
+
+### Problems?
+If you run into problems please [create an issue](https://github.com/simonvanderveldt/simonvanderveldt-overlay/issues/new) or send a pull request if you already know how to fix it :)
+
+## Automated quality control
+- GitHub's [branch protection](https://help.github.com/articles/about-protected-branches/) is enabled for the `master` branch
+- Changes can only be done using [pull requests](https://help.github.com/articles/about-pull-requests/)
+- Pull requests can only be merged if they pass the automated tests, which are run by [Travis CI](https://travis-ci.org)
+
+## Automated tests
+The following tests are run for every pull request:
+- [repoman](https://wiki.gentoo.org/wiki/Repoman) checks:
+ - `full` to check if the overlay and ebuilds are correct
+ - `--xmlparse` to check if the `metadata.xml` files are correct

--- a/tests/app-portage/repoman/repoman-2.3.1.ebuild
+++ b/tests/app-portage/repoman/repoman-2.3.1.ebuild
@@ -1,0 +1,79 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
+PYTHON_REQ_USE='bzip2(+)'
+
+inherit distutils-r1
+
+if [[ ${PV} == 9999 ]]; then
+	inherit git-r3
+	EGIT_REPO_URI="https://anongit.gentoo.org/git/proj/portage.git"
+	S="${WORKDIR}/${P}/repoman"
+else
+	SRC_URI="https://github.com/simonvanderveldt/portage/archive/disable-irrelevant-checks-for-overlay.tar.gz"
+	S="${WORKDIR}/portage-disable-irrelevant-checks-for-overlay/repoman"
+	KEYWORDS="alpha amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~ppc-aix ~amd64-fbsd ~sparc-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+fi
+
+DESCRIPTION="Repoman is a Quality Assurance tool for Gentoo ebuilds"
+HOMEPAGE="https://wiki.gentoo.org/wiki/Project:Portage"
+
+LICENSE="GPL-2"
+SLOT="0"
+IUSE=""
+
+RDEPEND="
+	>=sys-apps/portage-2.3.0_rc[${PYTHON_USEDEP}]
+	>=dev-python/lxml-3.6.0[${PYTHON_USEDEP}]
+"
+DEPEND="${RDEPEND}"
+
+python_prepare_all() {
+	distutils-r1_python_prepare_all
+
+	if [[ -n "${EPREFIX}" ]] ; then
+		einfo "Prefixing shebangs ..."
+
+		local file
+		while read -r -d $'\0' file; do
+			local shebang=$(head -n1 "${file}")
+
+			if [[ ${shebang} == "#!"* && ! ${shebang} == "#!${EPREFIX}/"* ]] ; then
+				sed -i -e "1s:.*:#!${EPREFIX}${shebang:2}:" "${file}" || \
+					die "sed failed"
+			fi
+		done < <(find . -type f -print0)
+	fi
+}
+
+python_test() {
+	esetup.py test
+}
+
+python_install() {
+	# Install sbin scripts to bindir for python-exec linking
+	# they will be relocated in pkg_preinst()
+	distutils-r1_python_install \
+		--system-prefix="${EPREFIX}/usr" \
+		--bindir="$(python_get_scriptdir)" \
+		--docdir="${EPREFIX}/usr/share/doc/${PF}" \
+		--htmldir="${EPREFIX}/usr/share/doc/${PF}/html" \
+		--sbindir="$(python_get_scriptdir)" \
+		--sysconfdir="${EPREFIX}/etc" \
+		"${@}"
+}
+
+pkg_postinst() {
+	einfo ""
+	einfo "This release of repoman is from the new portage/repoman split"
+	einfo "release code base."
+	einfo "This new repoman code base is still being developed.  So its API's"
+	einfo "are not to be considered stable and are subject to change."
+	einfo "The code released has been tested and considered ready for use."
+	einfo "This however does not guarantee it to be completely bug free."
+	einfo "Please report any bugs you may encounter."
+	einfo ""
+}

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '2'
+services:
+  tests:
+    image: gentoo/stage3-amd64
+    volumes:
+      - "../:/overlay"
+    working_dir: "/overlay"
+    command: /overlay/tests/runtests.sh

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env sh
 set -x
 
-# First update portage and install dependencies
-emerge-webrsync
-emerge dev-vcs/git repoman
+# Update the portage tree and install dependencies
+PORTAGE_RSYNC_EXTRA_OPTS="-q" emerge --sync
+emerge -q --buildpkg --usepkg dev-vcs/git repoman
 
 # Run the tests
 repoman full

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -11,4 +11,4 @@ emerge -q --buildpkg --usepkg dev-vcs/git dev-python/lxml
 ebuild tests/app-portage/repoman/repoman-2.3.1.ebuild manifest clean merge
 
 # Run the tests
-repoman full
+repoman full --xmlparse

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env sh
 set -x
 
+# Disable news messages from portage and disable rsync's output
+export FEATURES="-news" PORTAGE_RSYNC_EXTRA_OPTS="-q"
+
 # Update the portage tree and install dependencies
-PORTAGE_RSYNC_EXTRA_OPTS="-q" emerge --sync
+emerge --sync
 emerge -q --buildpkg --usepkg dev-vcs/git repoman
 
 # Run the tests

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -8,7 +8,7 @@ export FEATURES="-news" PORTAGE_RSYNC_EXTRA_OPTS="-q"
 emerge --sync
 emerge -q --buildpkg --usepkg dev-vcs/git dev-python/lxml
 # Install fork or repoman with failing tests that are irrelevant for overlays stripped out
-ebuild tests/app-portage/repoman/repoman-2.3.1.ebuild manifest clean merge
+ebuild tests/app-portage/repoman/repoman-2.3.1.ebuild manifest clean merge  > /dev/null
 
 # Run the tests
 repoman full --xmlparse

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -6,7 +6,9 @@ export FEATURES="-news" PORTAGE_RSYNC_EXTRA_OPTS="-q"
 
 # Update the portage tree and install dependencies
 emerge --sync
-emerge -q --buildpkg --usepkg dev-vcs/git repoman
+emerge -q --buildpkg --usepkg dev-vcs/git dev-python/lxml
+# Install fork or repoman with failing tests that are irrelevant for overlays stripped out
+ebuild tests/app-portage/repoman/repoman-2.3.1.ebuild manifest clean merge
 
 # Run the tests
 repoman full

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -x
+
+# First update portage and install dependencies
+emerge-webrsync
+emerge dev-vcs/git repoman
+
+# Run the tests
+repoman full


### PR DESCRIPTION
Initially only runs `repoman full --xmlparse` to check if there are any obvious issues with the ebuilds and the overlay itself as well as with the `metadata.xml` files.