### PR TITLE
media-sound/carla fix liblo deps

### DIFF
--- a/media-sound/carla/carla-2.0_beta5_p1.ebuild
+++ b/media-sound/carla/carla-2.0_beta5_p1.ebuild
@@ -30,7 +30,8 @@ RDEPEND="!qt5? ( dev-python/PyQt4[X,svg] )
 	alsa? ( media-libs/alsa-lib )
 	pulseaudio? ( media-sound/pulseaudio )
 	X? ( x11-base/xorg-server )
-	osc? ( media-libs/liblo )
+	osc? ( media-libs/liblo
+		media-libs/pyliblo )
 	sf2? ( media-sound/fluidsynth )
 	gig? ( media-sound/linuxsampler )
 	sfz? ( media-sound/linuxsampler )
@@ -74,5 +75,8 @@ src_compile() {
 }
 
 src_install() {
-	emake PREFIX="/usr" DESTDIR="${D}" "${myemakeargs[@]}" install
+	emake DESTDIR="${D}" PREFIX="/usr" "${myemakeargs[@]}" install
+	if ! use osc; then
+		find "${D}/usr" -iname "carla-control*" | xargs rm
+	fi
 }

--- a/media-sound/carla/carla-9999-r2.ebuild
+++ b/media-sound/carla/carla-9999-r2.ebuild
@@ -28,7 +28,8 @@ RDEPEND="!qt5? ( dev-python/PyQt4[X,svg] )
 	alsa? ( media-libs/alsa-lib )
 	pulseaudio? ( media-sound/pulseaudio )
 	X? ( x11-base/xorg-server )
-	osc? ( media-libs/liblo )
+	osc? ( media-libs/liblo
+		media-libs/pyliblo )
 	sf2? ( media-sound/fluidsynth )
 	gig? ( media-sound/linuxsampler )
 	sfz? ( media-sound/linuxsampler )
@@ -72,5 +73,8 @@ src_compile() {
 }
 
 src_install() {
-	emake PREFIX="/usr" DESTDIR="${D}" "${myemakeargs[@]}" install
+	emake DESTDIR="${D}" PREFIX="/usr" "${myemakeargs[@]}" install
+	if ! use osc; then
+		find "${D}/usr" -iname "carla-control*" | xargs rm
+	fi
 }


### PR DESCRIPTION
Also, don't install apps (carla-control) that need liblo when the osc USE flag is disabled