### PR TITLE
media-sound/carla-9999-r2: remove broken patch from live ebuild

### DIFF
--- a/media-sound/carla/carla-9999-r2.ebuild
+++ b/media-sound/carla/carla-9999-r2.ebuild
@@ -44,8 +44,6 @@ RDEPEND="!qt5? ( dev-python/PyQt4[X,svg] )
 	zynaddsubfx-ui? ( x11-libs/fltk )"
 DEPEND=${RDEPEND}
 
-PATCHES=( "${FILESDIR}/${PN}-fix-xdg-desktop-categories.patch" )
-
 src_compile() {
 	myemakeargs=(
 		USE_COLORS=false


### PR DESCRIPTION
This patch is broken by recent commit, which updates categories, but without replacing it to AudioVideoEditing. Yet it is not going to support it (as i was said in IRC, it makes no sence).